### PR TITLE
Add guest feature with anonymous sign in enabled

### DIFF
--- a/App.js
+++ b/App.js
@@ -43,7 +43,6 @@ const App = () => {
       </Stack.Navigator>
     );
   
-
   return (
     <RootSiblingParent>
     <NavigationContainer>

--- a/Screens/BookingsScreen.js
+++ b/Screens/BookingsScreen.js
@@ -1,11 +1,15 @@
 import React, { useState } from "react";
 import { Text, View } from 'react-native';
 import styles from '../css/TemplateScreenStyle';
+import { isAnonymous } from "firebase/auth";
+import { auth } from '../firebase/index';
 
 function BookingsScreen() {
     return (
       <View style={styles.page}>
-        <Text styles={styles.headerText}> Bookings are made here! </Text>
+        {auth.currentUser.isAnonymous ? 
+        <Text styles={styles.headerText}> You are a guest. Bookings are only available to NUS staff and students.</Text>
+        : <Text styles={styles.headerText}>Bookings are made here!</Text>}
       </View>
     );
   }

--- a/Screens/LocationsScreen.js
+++ b/Screens/LocationsScreen.js
@@ -55,7 +55,7 @@ function LocationsScreen() {
       </Modal>
 
       <View style={styles.header}>
-        <Text style={styles.headerText}> Home</Text>
+        <Text style={styles.headerText}> Locations</Text>
         <Pressable
           style={styles.profileIcon}
           onPress={() => setModalVisible(true)}

--- a/Screens/Login.js
+++ b/Screens/Login.js
@@ -4,7 +4,7 @@ import {
     Keyboard, KeyboardAvoidingView, Platform
 } from "react-native";
 import React, { useState } from 'react';
-import { signInWithEmailAndPassword, sendPasswordResetEmail } from "firebase/auth";
+import { signInWithEmailAndPassword, sendPasswordResetEmail, signInAnonymously } from "firebase/auth";
 import { auth } from '../firebase/index';
 import Toast from 'react-native-root-toast';
 
@@ -44,6 +44,16 @@ const LoginPage = ({ navigation }) => {
         }, 3000);
     };
 
+    const guestToast = () => {
+        let toast = Toast.show('You signed in as a guest.', {
+            duration: Toast.durations.LONG,
+            position: Toast.positions.CENTER,
+        });
+        setTimeout(function hideToast() {
+            Toast.hide(toast);
+        }, 3000);
+    };
+
     // toast is working. email can only be sent if the domain is ready.
     const passwordResetHandler = () => {
         passwordResetToast();
@@ -74,7 +84,6 @@ const LoginPage = ({ navigation }) => {
             
             .catch(error => {
                 wrongFieldsToast();
-                return;
                 const errorCode = error.code;
                 const errorMessage = error.message;
                 console.error('[loginHandler]', errorCode, errorMessage);
@@ -86,6 +95,19 @@ const LoginPage = ({ navigation }) => {
         setPassword('');
         Keyboard.dismiss();
     };
+
+    const guestHandler = () => {
+        guestToast();
+        return signInAnonymously(auth)
+        .then(() => {
+          // Signed in..
+        })
+        .catch((error) => {
+          const errorCode = error.code;
+          const errorMessage = error.message;
+          // ...
+        });
+    }
 
     return (
         <KeyboardAvoidingView style={styles.container}>
@@ -136,7 +158,7 @@ const LoginPage = ({ navigation }) => {
                     <Text style={styles.signUpLinkText}>New to DestiNUS? Create account here</Text>
                 </Pressable>
                 <Pressable
-                    //onPress={}
+                    onPress={guestHandler}
                     style={styles.guestButton}
                     android_ripple={{ color: '#FFF' }}
                 >


### PR DESCRIPTION
1. Anonymous sign in is enabled on firebase console. 
2. Guest button is working now.
3. Toast for successfully signing as guest is added

I have 2 ideas: 

1. Initially, the idea was allowing all users to use the locations feature without being signed into the app. Only verified users can access the booking feature. However, I chanced upon the anonymous sign in feature.
4. Without restructuring the current flow of authentication (i.e. being verified to use the app features), anonymous sign in was used. If the user is anonymous (i.e. using the app as a guest), the booking feature will be blocked off.

TL;DR: If you signed in as a guest (Pressing `Continue as guest` button), you will not see something on the Bookings tab non-anonymous users usually see.

Note: 
1. Look into the reason `isAnonymous` method does not need to be imported.
2. Add a delete user function when anonymous user closes the app.